### PR TITLE
Fix warning about <body> being missed

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,13 +25,15 @@ export default function RootLayout({
   );
   return (
     <html lang="en">
-      <NextAuthProvider>
-        <ErudaProvider>
-          <MiniKitProvider>
-            <body className={inter.className}>{children}</body>
-          </MiniKitProvider>
-        </ErudaProvider>
-      </NextAuthProvider>
+      <body className={inter.className}>
+        <NextAuthProvider>
+          <ErudaProvider>
+            <MiniKitProvider>
+              {children}
+            </MiniKitProvider>
+          </ErudaProvider>
+        </NextAuthProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
when loading the app there is a warning saying:

the following tags are missing in the root layout: <body>

this update fix the warning